### PR TITLE
Add marektDomain to sample app for PrePurchase

### DIFF
--- a/TMSDKDemoIntegration.xcodeproj/project.pbxproj
+++ b/TMSDKDemoIntegration.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		59073DBD2C91C91C002597BF /* MenuButtonWithTitleAndPopupMenuTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59073DBB2C91C91C002597BF /* MenuButtonWithTitleAndPopupMenuTableViewCell.swift */; };
+		59073DBE2C91C91C002597BF /* MenuButtonWithTitleAndPopupMenuTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 59073DBC2C91C91C002597BF /* MenuButtonWithTitleAndPopupMenuTableViewCell.xib */; };
+		59073DC02C931F65002597BF /* MarketLocation+AdditionalMarkets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59073DBF2C931F65002597BF /* MarketLocation+AdditionalMarkets.swift */; };
 		790B04782BB4B70C009BA193 /* MenuTitleSubtitleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790B04762BB4B70C009BA193 /* MenuTitleSubtitleTableViewCell.swift */; };
 		790B04792BB4B70C009BA193 /* MenuTitleSubtitleTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 790B04772BB4B70C009BA193 /* MenuTitleSubtitleTableViewCell.xib */; };
 		792846102A57599000383C42 /* DiscoveryHelper+Configure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7928460F2A57599000383C42 /* DiscoveryHelper+Configure.swift */; };
@@ -128,6 +131,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		59073DBB2C91C91C002597BF /* MenuButtonWithTitleAndPopupMenuTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuButtonWithTitleAndPopupMenuTableViewCell.swift; sourceTree = "<group>"; };
+		59073DBC2C91C91C002597BF /* MenuButtonWithTitleAndPopupMenuTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MenuButtonWithTitleAndPopupMenuTableViewCell.xib; sourceTree = "<group>"; };
+		59073DBF2C931F65002597BF /* MarketLocation+AdditionalMarkets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MarketLocation+AdditionalMarkets.swift"; sourceTree = "<group>"; };
 		790B04762BB4B70C009BA193 /* MenuTitleSubtitleTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuTitleSubtitleTableViewCell.swift; sourceTree = "<group>"; };
 		790B04772BB4B70C009BA193 /* MenuTitleSubtitleTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MenuTitleSubtitleTableViewCell.xib; sourceTree = "<group>"; };
 		7928460F2A57599000383C42 /* DiscoveryHelper+Configure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiscoveryHelper+Configure.swift"; sourceTree = "<group>"; };
@@ -456,6 +462,7 @@
 				795D32AD2A565EA7001D0466 /* PrePurchaseViewController.swift */,
 				795D32B22A565EA7001D0466 /* PrePurchaseVC+BuildMenu.swift */,
 				795D32B12A565EA7001D0466 /* PrePurchaseVC+Actions.swift */,
+				59073DBF2C931F65002597BF /* MarketLocation+AdditionalMarkets.swift */,
 			);
 			path = PrePurchase;
 			sourceTree = "<group>";
@@ -519,6 +526,8 @@
 				790B04772BB4B70C009BA193 /* MenuTitleSubtitleTableViewCell.xib */,
 				79E8C0122A56290F0054B340 /* MenuTitleTableViewCell.swift */,
 				79E8C0192A56290F0054B340 /* MenuTitleTableViewCell.xib */,
+				59073DBB2C91C91C002597BF /* MenuButtonWithTitleAndPopupMenuTableViewCell.swift */,
+				59073DBC2C91C91C002597BF /* MenuButtonWithTitleAndPopupMenuTableViewCell.xib */,
 			);
 			path = MenuCells;
 			sourceTree = "<group>";
@@ -621,6 +630,7 @@
 				79E8C0212A56290F0054B340 /* MenuTextFieldWithTitleTableViewCell.xib in Resources */,
 				79E8C02E2A56290F0054B340 /* MenuSwitchWithTitleTableViewCell.xib in Resources */,
 				79E8C0222A56290F0054B340 /* MenuBlankTableViewCell.xib in Resources */,
+				59073DBE2C91C91C002597BF /* MenuButtonWithTitleAndPopupMenuTableViewCell.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -657,6 +667,7 @@
 				79E8C0642A5631B70054B340 /* AuthenticationHelper.swift in Sources */,
 				79E8C03F2A56291F0054B340 /* MenuBuilderDataSource+Configure.swift in Sources */,
 				79E8C0252A56290F0054B340 /* MenuTextFieldTableViewCell.swift in Sources */,
+				59073DC02C931F65002597BF /* MarketLocation+AdditionalMarkets.swift in Sources */,
 				79E8C0702A563C380054B340 /* TicketsHelper+OrderDelegate.swift in Sources */,
 				79E8C02A2A56290F0054B340 /* MenuSwitchWithTitleTableViewCell.swift in Sources */,
 				79E8C0892A5656BF0054B340 /* DictionaryExplorerViewController.swift in Sources */,
@@ -688,6 +699,7 @@
 				79E8C0302A56290F0054B340 /* MenuBlankTableViewCell.swift in Sources */,
 				79CD14A72A8D4CFA00542D92 /* EmbeddedViewController.swift in Sources */,
 				79BC56022A574BCE00E082E1 /* AuthenticationVC+Notifications.swift in Sources */,
+				59073DBD2C91C91C002597BF /* MenuButtonWithTitleAndPopupMenuTableViewCell.swift in Sources */,
 				795D32EB2A567499001D0466 /* DiscoveryHelper+Present.swift in Sources */,
 				79E8C0782A563D310054B340 /* TicketsHelper+CustomModules.swift in Sources */,
 				79E8C06A2A5636170054B340 /* PrePurchaseHelper.swift in Sources */,

--- a/TMSDKDemoIntegration/Logic/PrePurchase/PrePurchaseHelper+Present.swift
+++ b/TMSDKDemoIntegration/Logic/PrePurchase/PrePurchaseHelper+Present.swift
@@ -13,6 +13,7 @@ extension PrePurchaseHelper {
         
     func viewControllerForCurrentConfiguration(page: TMPrePurchaseViewController.PrePurchasePage) -> TMPrePurchaseViewController {
         let prePurchaseVC = TMPrePurchaseViewController(initialPage: page,
+                                                        marketDomain: forcedMarketDomain,
                                                         marketLocation: homepageMarketLocation, // if showing homepage
                                                         queryParameters: nil,
                                                         enclosingEnvironment: .navigationController,

--- a/TMSDKDemoIntegration/Logic/PrePurchase/PrePurchaseHelper.swift
+++ b/TMSDKDemoIntegration/Logic/PrePurchase/PrePurchaseHelper.swift
@@ -15,6 +15,7 @@ class PrePurchaseHelper: NSObject {
     
     weak var prePurchaseMenuVC: PrePurchaseViewController?
 
+    var forcedMarketDomain: MarketDomain = MarketDomain.US
     var homepageMarketLocation: MarketLocation = MarketLocation.California_LosAngeles()
     
     lazy var clLocationManager: CLLocationManager = {

--- a/TMSDKDemoIntegration/Menus/MenuBuilder/MenuBuilderCellInfo.swift
+++ b/TMSDKDemoIntegration/Menus/MenuBuilder/MenuBuilderCellInfo.swift
@@ -121,6 +121,7 @@ enum MenuBuilderCellType: String, CaseIterable {
     case titleSubtitle
     case button
     case buttonWithTitle
+    case buttonWithTitleAndPopupMenu
     case textField
     case textFieldWithTitle
     case segmentedControl
@@ -139,6 +140,8 @@ enum MenuBuilderCellType: String, CaseIterable {
             return "MenuButtonTableViewCell"
         case .buttonWithTitle:
             return "MenuButtonWithTitleTableViewCell"
+        case .buttonWithTitleAndPopupMenu:
+            return "MenuButtonWithTitleAndPopupMenuTableViewCell"
         case .textField:
             return "MenuTextFieldTableViewCell"
         case .textFieldWithTitle:

--- a/TMSDKDemoIntegration/Menus/MenuBuilder/MenuBuilderDataSource+Action.swift
+++ b/TMSDKDemoIntegration/Menus/MenuBuilder/MenuBuilderDataSource+Action.swift
@@ -65,6 +65,12 @@ extension MenuBuilderDataSource: MenuButtonTableViewCellDelegate {
     }
 }
 
+extension MenuBuilderDataSource: PopupMenuTableviewCellDelegate {
+    func valueChanged(_ cell: MenuButtonWithTitleAndPopupTableViewCell, value: String) {
+        delegate?.menuBuilderDataSource(self, didAction: .valueChanged(value: value), forCell: cell)
+    }
+}
+
 extension MenuBuilderDataSource: MenuTextWithButtonTableViewCellDelegate {
     func buttonPressed(_ cell: MenuButtonWithTitleTableViewCell) {
         delegate?.menuBuilderDataSource(self, didAction: .buttonPressed(title: cell.valueButton.title(for: .normal) ?? ""), forCell: cell)

--- a/TMSDKDemoIntegration/Menus/MenuBuilder/MenuBuilderDataSource+BuildCells.swift
+++ b/TMSDKDemoIntegration/Menus/MenuBuilder/MenuBuilderDataSource+BuildCells.swift
@@ -44,6 +44,12 @@ extension MenuBuilderDataSource {
             customCell.delegate = self
             cell = customCell
             
+        case .buttonWithTitleAndPopupMenu:
+            let customCell = tableView.dequeueReusableCell(withIdentifier: cellInfo.cellType.rawValue) as! MenuButtonWithTitleAndPopupTableViewCell
+            customCell.configure(withCellInfo: cellInfo)
+            customCell.delegate = self
+            cell = customCell
+            
         case .textField:
             let customCell = tableView.dequeueReusableCell(withIdentifier: cellInfo.cellType.rawValue) as! MenuTextFieldTableViewCell
             customCell.configure(withCellInfo: cellInfo)

--- a/TMSDKDemoIntegration/Menus/MenuBuilder/MenuBuilderDataSource+Update.swift
+++ b/TMSDKDemoIntegration/Menus/MenuBuilder/MenuBuilderDataSource+Update.swift
@@ -50,6 +50,13 @@ extension MenuBuilderDataSource {
                         cell.update(title: title)
                     }
                 }
+            case .buttonWithTitleAndPopupMenu:
+                cellInfo.titleText = title
+                if let cell = loadedCell as? MenuButtonWithTitleAndPopupTableViewCell {
+                    DispatchQueue.main.async {
+                        cell.update(title: title)
+                    }
+                }
             case .textField:
                 // no title, but update placeholder text
                 cellInfo.placeholderText = title
@@ -123,6 +130,15 @@ extension MenuBuilderDataSource {
                 if let value = value {
                     cellInfo.valueText = value
                     if let cell = loadedCell as? MenuButtonWithTitleTableViewCell {
+                        DispatchQueue.main.async {
+                            cell.update(buttonTitle: value)
+                        }
+                    }
+                }
+            case .buttonWithTitleAndPopupMenu:
+                if let value = value {
+                    cellInfo.valueText = value
+                    if let cell = loadedCell as? MenuButtonWithTitleAndPopupTableViewCell {
                         DispatchQueue.main.async {
                             cell.update(buttonTitle: value)
                         }

--- a/TMSDKDemoIntegration/Menus/MenuBuilder/MenuCells/MenuButtonWithTitleAndPopupMenuTableViewCell.swift
+++ b/TMSDKDemoIntegration/Menus/MenuBuilder/MenuCells/MenuButtonWithTitleAndPopupMenuTableViewCell.swift
@@ -1,0 +1,73 @@
+//
+//  MenuButtonWithTitleAndPopupMenuTableViewCell.swift
+//  RetailDevApp
+//
+//  Created by Vishwak Reddy on 09/11/2024.
+//
+
+import UIKit
+
+protocol PopupMenuTableviewCellDelegate: AnyObject {
+    func valueChanged(_ cell: MenuButtonWithTitleAndPopupTableViewCell, value: String)
+}
+
+class MenuButtonWithTitleAndPopupTableViewCell: MenuBuilderTableViewCell {
+    
+    @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet weak var valueButton: UIButton!
+    
+    weak var delegate: PopupMenuTableviewCellDelegate?
+    
+    // MARK: Constructors
+    func configure(withCellInfo cellInfo: MenuBuilderCellInfo) {
+        guard cellInfo.cellType == .buttonWithTitleAndPopupMenu else { return }
+        self.cellInfo = cellInfo
+        self.accessoryType = cellInfo.accessoryType
+
+        titleLabel.text = cellInfo.titleText
+        valueButton.setTitle(cellInfo.valueText, for: .normal)
+        
+        titleLabel.textColor = cellInfo.titleColor ?? .label
+        valueButton.tintColor = cellInfo.valueColor ?? contentView.tintColor
+        contentView.backgroundColor = cellInfo.backgroundColor
+       
+        valueButton.menu = UIMenu(title: "", children: menuActions())
+        valueButton.showsMenuAsPrimaryAction = true
+
+    }
+
+    // MARK: Updates
+    func update(title: String) {
+        titleLabel.text = title
+    }
+    
+    func update(buttonTitle: String) {
+        valueButton.setTitle(buttonTitle, for: .normal)
+    }
+
+}
+
+extension MenuButtonWithTitleAndPopupTableViewCell {
+    func menuActions() -> [UIMenuElement] {
+        guard let valueArray = cellInfo.valueArray else { return []}
+        var actions = [UIMenuElement]()
+        for (index, value) in valueArray.enumerated() {
+            var title: String
+            if let titlesArray = cellInfo.segmentTextArray,
+               index < titlesArray.count
+            {
+                title = titlesArray[index]
+            } else {
+                title = value
+            }
+
+            actions.append(
+                UIAction(title: title) { [weak self] action in
+                    guard let self else { return }
+                    self.delegate?.valueChanged(self, value: value)
+                }
+            )
+        }
+        return actions
+    }
+}

--- a/TMSDKDemoIntegration/Menus/MenuBuilder/MenuCells/MenuButtonWithTitleAndPopupMenuTableViewCell.xib
+++ b/TMSDKDemoIntegration/Menus/MenuBuilder/MenuCells/MenuButtonWithTitleAndPopupMenuTableViewCell.xib
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="MenuButtonWithTitleAndPopupTableViewCell" customModule="RetailDevAppNav" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title Text" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oXr-G1-O1Z">
+                        <rect key="frame" x="10" y="7" width="62.5" height="30"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="l7s-uh-4La">
+                        <rect key="frame" x="222" y="7" width="88" height="30"/>
+                        <state key="normal" title="Value Button"/>
+                    </button>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="oXr-G1-O1Z" firstAttribute="bottom" secondItem="H2p-sc-9uM" secondAttribute="bottom" constant="-7" id="Gx3-t5-yvp"/>
+                    <constraint firstItem="oXr-G1-O1Z" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="l7s-uh-4La" secondAttribute="leading" constant="-10" id="SGR-xO-NUb"/>
+                    <constraint firstItem="l7s-uh-4La" firstAttribute="trailing" secondItem="H2p-sc-9uM" secondAttribute="trailing" constant="-10" id="Vva-ha-2n5"/>
+                    <constraint firstItem="oXr-G1-O1Z" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="10" id="cCg-rm-gJ6"/>
+                    <constraint firstItem="l7s-uh-4La" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="7" id="dzx-Vy-AwF"/>
+                    <constraint firstItem="l7s-uh-4La" firstAttribute="bottom" secondItem="H2p-sc-9uM" secondAttribute="bottom" constant="-7" id="g1w-1l-xck"/>
+                    <constraint firstItem="oXr-G1-O1Z" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="7" id="wqR-1l-ki3"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="titleLabel" destination="oXr-G1-O1Z" id="XNd-ui-ZL5"/>
+                <outlet property="valueButton" destination="l7s-uh-4La" id="E05-1i-CHX"/>
+            </connections>
+            <point key="canvasLocation" x="123" y="154"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/TMSDKDemoIntegration/Menus/PrePurchase/MarketLocation+AdditionalMarkets.swift
+++ b/TMSDKDemoIntegration/Menus/PrePurchase/MarketLocation+AdditionalMarkets.swift
@@ -1,0 +1,77 @@
+//
+//  MarketLocation+Extensions.swift
+//  RetailDevApp
+//
+//  Created by Andrew Rennard on 12/02/2024.
+//
+
+import Foundation
+import CoreLocation
+import TicketmasterFoundation
+
+extension MarketLocation {
+    static func defaultLocationFor(market: MarketDomain) -> MarketLocation {
+        switch market {
+        case .CA: MarketLocation.Canada_BritishColumbia_Vancouver()
+        case .AU: MarketLocation.Australia_Sydney()
+        case .MX: MarketLocation.Mexico_MexicoCity()
+        case .NZ: MarketLocation.NewZealand_Auckland()
+        case .UK: MarketLocation.UK_London()
+        case .IE: MarketLocation.IE_Dublin()
+        default: MarketLocation.California_LosAngeles()
+        }
+    }
+}
+
+extension MarketLocation {
+    
+    static func Australia_Sydney() -> MarketLocation {
+        let domain: MarketDomain = .AU
+        let marketID: Int = 307
+        let marketName: String = "Sydney"
+        let description: String = "Sydney, AU"
+        let clLocation: CLLocation = CLLocation(latitude: -33.87271, longitude: 151.20569)
+        
+        return MarketLocation(domain: domain, identifier: "\(marketID)", name: marketName, localizedName: description, dmaId: nil, countryCode: domain.countryCode, userLocation: UserLocation(location: clLocation, source: .appMarketList), source: .appMarketList)
+    }
+    
+    static func Mexico_MexicoCity() -> MarketLocation {
+        let domain: MarketDomain = .MX
+        let marketID: Int = 402
+        let marketName: String = "Mexico City"
+        let description: String = "Mexico City, MX"
+        let clLocation: CLLocation = CLLocation(latitude: 19.43011, longitude: 99.13361)
+        
+        return MarketLocation(domain: domain, identifier: "\(marketID)", name: marketName, localizedName: description, dmaId: nil, countryCode: domain.countryCode, userLocation: UserLocation(location: clLocation, source: .appMarketList), source: .appMarketList)
+    }
+    
+    static func NewZealand_Auckland() -> MarketLocation {
+        let domain: MarketDomain = .NZ
+        let marketID: Int = 351
+        let marketName: String = "Auckland"
+        let description: String = "Auckland, NZ"
+        let clLocation: CLLocation = CLLocation(latitude: -36.85307, longitude: 174.76358)
+        
+        return MarketLocation(domain: domain, identifier: "\(marketID)", name: marketName, localizedName: description, dmaId: nil, countryCode: domain.countryCode, userLocation: UserLocation(location: clLocation, source: .appMarketList), source: .appMarketList)
+    }
+    
+    static func UK_London() -> MarketLocation {
+        let domain: MarketDomain = .UK
+        let marketID: Int = 202
+        let marketName: String = "London"
+        let description: String = "London, UK"
+        let clLocation: CLLocation = CLLocation(latitude: 51.51, longitude: -0.12)
+        
+        return MarketLocation(domain: domain, identifier: "\(marketID)", name: marketName, localizedName: description, dmaId: nil, countryCode: domain.countryCode, userLocation: UserLocation(location: clLocation, source: .appMarketList), source: .appMarketList)
+    }
+    
+    static func IE_Dublin() -> MarketLocation {
+        let domain: MarketDomain = .IE
+        let marketID: Int = 208
+        let marketName: String = "Dublin"
+        let description: String = "Dublin, IE"
+        let clLocation: CLLocation = CLLocation(latitude: 53.35, longitude: -6.27)
+        
+        return MarketLocation(domain: domain, identifier: "\(marketID)", name: marketName, localizedName: description, dmaId: nil, countryCode: domain.countryCode, userLocation: UserLocation(location: clLocation, source: .appMarketList), source: .appMarketList)
+    }
+}

--- a/TMSDKDemoIntegration/Menus/PrePurchase/PrePurchaseVC+Actions.swift
+++ b/TMSDKDemoIntegration/Menus/PrePurchase/PrePurchaseVC+Actions.swift
@@ -51,6 +51,18 @@ extension PrePurchaseViewController: MenuBuilderDataSourceDelegate {
                     prePurchaseHelper.presentPrePurchase(page: .attraction(identifier: attractionID),
                                                          onViewController: self)
                 }
+                
+            case .settingsDomain:
+                switch action {
+                case .valueChanged(let value):
+                    if let value = value, let market = MarketDomain(rawValue: value.lowercased()) {
+                        prePurchaseHelper.forcedMarketDomain = market
+                        prePurchaseHelper.homepageMarketLocation = MarketLocation.defaultLocationFor(market: market)
+                    }
+                    buildRefreshMenu()
+                default:
+                    break
+                }
             }
         }
     }


### PR DESCRIPTION
Update Sample App UI in PrePurchase to include marketDomain to support local locations for International clients

![Screen3](https://github.com/user-attachments/assets/d4b71dae-68c5-47b9-a062-2656a9aad46d)
